### PR TITLE
add a section on Theme Maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The Theme Collection team will validate your theme (using manual review and/or a
 
 All Themes in the Themes Collection are maintained by the Notepad++ user base, purely on a volunteer basis.
 
-The original author of a given Theme is encouraged to return and make updates to the themes as necessary -- for example, when Notepad++ adds new Languages to the available lexers, it would be helpful if the original Theme author would come back and add in the definition for that language with the colors of their Theme.
+The original author of a given Theme is encouraged to return and make updates to the themes as necessary -- for example, when Notepad++ adds new languages to the available lexers, it would be helpful if the original Theme author would come back and add in the definitions for those languages with the colors of their Theme.
 
 However, as this is a user-based Collection, and all the Themes are released as open source, they can be modified by other users... so if you see that your favorite Theme from this Collection is missing one or more lexer languages, feel free to add those languages into the theme, and create a PR (or attach the updated XML to an issue) to update that Theme with the new languages, so that the Themes in this Collection are kept as up-to-date with Notepad++ as possible.
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ The Theme Collection team will validate your theme (using manual review and/or a
 
 All Themes in the Themes Collection are maintained by the Notepad++ user base, purely on a volunteer basis.
 
-It is desired and hoped that the original author of a given Theme will return and make updates to the themes -- for example, when Notepad++ adds new Languages to the available lexers, the original Theme author should come back and add in the definition for that language with the colors of their theme.
+The original author of a given Theme is encouraged to return and make updates to the themes as necessary -- for example, when Notepad++ adds new Languages to the available lexers, it would be helpful if the original Theme author would come back and add in the definition for that language with the colors of their Theme.
 
-However, as this is a user-based Collection, and all the Themes are released as open source, they can be modified by other users... so if you see that your favorite Theme from this Collection is missing one or more lexer languages, feel free to add those languages into the theme, and create a PR (or attach the updated XML to an issue, if you don't know how to do PR) to update that Theme with the new languages, so that the Themes in this Collection are kept as up-to-date with Notepad++ as possible.
+However, as this is a user-based Collection, and all the Themes are released as open source, they can be modified by other users... so if you see that your favorite Theme from this Collection is missing one or more lexer languages, feel free to add those languages into the theme, and create a PR (or attach the updated XML to an issue) to update that Theme with the new languages, so that the Themes in this Collection are kept as up-to-date with Notepad++ as possible.
 
-The administrators of the Themes Collection are _not_ responsible for maintaining the individual themes.  They are here to facilitate adding Themes to the collection, not to do the work of creating and maintaining Themes.  Do not expect to create an issue of "fix the colors in Theme XXX" or "add language ZZZ to all the themes"; such issues are likely to be rejected.  (Though the administrators reserve the right to be in a helpful mood and actually do all that extra work, they definitely do not guarantee that they will always be so accommodating, as that is not their job for this Collection.)
+The administrators of the Themes Collection are _not_ responsible for maintaining the individual themes.  They are here to facilitate adding Themes to the collection, not to do the work of creating and maintaining Themes.  Do not expect to create an issue of "fix the colors in Theme XXX" or "add language ZZZ to all the themes"; such issues are likely to be rejected.
 
 ## Automatic License
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,20 @@ See the [default styler](https://github.com/notepad-plus-plus/notepad-plus-plus/
 You can submit your Theme file(s) into this repo if you would like to share it with the general public.  
 
 To do so, you may either:
-- Create a Pull Request: create your own fork of this repository; add the new theme XML file to the themes folder your fork; and finally, create the Pull Request (PR).
+- Create a Pull Request (PR): create your own fork of this repository; add the new theme XML file to the themes folder your fork; and finally, create the Pull Request (PR).
 - or Create a new Issue: go to the [issues](../../issues) page for this repository, click on the **New issue** button, give it a meaningful issue name, and attach the theme's .XML file to the issue, then submit the issue.
 
 The Theme Collection team will validate your theme (using manual review and/or automated tools), and will decide whether or not to accept your submission.  Following the Best Practices (above) will help ensure your submitted Theme is added into the Collection.
+
+## Theme Maintenance
+
+All Themes in the Themes Collection are maintained by the Notepad++ user base, purely on a volunteer basis.
+
+It is desired and hoped that the original author of a given Theme will return and make updates to the themes -- for example, when Notepad++ adds new Languages to the available lexers, the original Theme author should come back and add in the definition for that language with the colors of their theme.
+
+However, as this is a user-based Collection, and all the Themes are released as open source, they can be modified by other users... so if you see that your favorite Theme from this Collection is missing one or more lexer languages, feel free to add those languages into the theme, and create a PR (or attach the updated XML to an issue, if you don't know how to do PR) to update that Theme with the new languages, so that the Themes in this Collection are kept as up-to-date with Notepad++ as possible.
+
+The administrators of the Themes Collection are _not_ responsible for maintaining the individual themes.  They are here to facilitate adding Themes to the collection, not to do the work of creating and maintaining Themes.  Do not expect to create an issue of "fix the colors in Theme XXX" or "add language ZZZ to all the themes"; such issues are likely to be rejected.  (Though the administrators reserve the right to be in a helpful mood and actually do all that extra work, they definitely do not guarantee that they will always be so accommodating, as that is not their job for this Collection.)
 
 ## Automatic License
 


### PR DESCRIPTION
Make it clear to the users of the Themes Collection that the administrators of the collection are here to facilitate the collection, and are not expected to keep Themes up to date as new Languages become available.