### PR TITLE
Submit OneNotepad++.Dark.xml theme per caskexe request

### DIFF
--- a/themes/.toc.json
+++ b/themes/.toc.json
@@ -2,5 +2,6 @@
     "99er.xml",
     "Dust Light.xml",
     "Industrial Whir.xml",
+    "OneNotepad++.Dark.xml",
     "Tangara-FontFree.xml"
 ]

--- a/themes/OneNotepad++.Dark.xml
+++ b/themes/OneNotepad++.Dark.xml
@@ -1,0 +1,1838 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<NotepadPlus>
+<!--
+		OneNotepad++
+		A dark theme style based on that of the OneNote dark mode colour palette.
+		Theme by [CASK] (CASK.exe - github.com/caskexe)
+-->
+
+<!--
+
+  Style name:   	OneNotepad++
+  Author:       	CASK.exe
+  Date:         	18 Jul 2025
+  License:      	MIT (https://choosealicense.com/licenses/mit/)
+  Description:  	A dark theme style based on that of the OneNote dark mode colour palette
+  Languages:    	Should work with all languages without issue but hasn't been tested on absolutely every one of them.
+
+-->
+    <LexerStyles>
+        <LexerType name="actionscript" desc="ActionScript" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="gdscript" desc="GDScript" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="808080" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="0080C0" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="3" fgColor="80FF80" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="80FF80" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="WORD" styleID="5" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="FFFF80" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TRIPLE DOUBLE" styleID="7" fgColor="FFFF80" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="80FFFF" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNC NAME" styleID="9" fgColor="FF80FF" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CBB6B6" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="FFFFFF" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="12" fgColor="008000" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING EOL" styleID="13" fgColor="FF80C0" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="WORD2" styleID="14" fgColor="FF80C0" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="ANNOTATION" styleID="15" fgColor="FFFF80" bgColor="2A2A2A" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="NODEPATH" styleID="16" fgColor="008040" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FF8080" bgColor="2A2A2A" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="ada" desc="ADA" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LABEL" styleID="9" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="EBD6EB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="asn1" desc="ASN.1" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIERS" styleID="2" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="3" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMERIC OID DEFINITION" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NON OID NUMBERS" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="6" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="ATTRIBUTES" styleID="7" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="DESCRIPTORS" styleID="8" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="TYPES" styleID="9" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="OPERATORS" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="asp" desc="asp" ext="asp">
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="82" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="83" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="WORD" styleID="84" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="85" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ASP SYMBOL" styleID="15" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SCRIPT TYPE" styleID="16" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="asm" desc="Assembly" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="3" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="REGISTER" styleID="8" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="2" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type4"></WordsStyle>
+        </LexerType>
+        <LexerType name="autoit" desc="autoIt" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="MACRO" styleID="6" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="SENT" styleID="10" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="EXPAND" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type5"></WordsStyle>
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="avs" desc="AviSynth" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="WHITE SPACE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT: /* */" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT: [* *]" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="LINE COMMENT: #" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATORS" styleID="5" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIERS" styleID="6" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING WITH THREE DOUBLE QUOTES" styleID="8" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="9" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="FILTER" styleID="10" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="PLUGIN" styleID="11" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="12" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="CLIP PROPERTIES" styleID="13" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="USER DEFINED" styleID="14" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type4"></WordsStyle>
+        </LexerType>
+        <LexerType name="baanc" desc="BaanC" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="4" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="5" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="6" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING EOL NC" styleID="9" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTIONS" styleID="10" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="FUNCTIONS ABRIDGED" styleID="11" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="SUB SECTIONS" styleID="12" fgColor="FF4500" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="MAIN SECTIONS" styleID="13" fgColor="800080" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="PREDEFINED VARIABLE" styleID="14" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="PREDEFINED ATTRIBUTES" styleID="15" fgColor="FF0080" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type5"></WordsStyle>
+            <WordsStyle name="ENUM DOMAINS" styleID="16" fgColor="000080" bgColor="FFFF80" fontName="" fontStyle="1" fontSize="" keywordClass="type6"></WordsStyle>
+            <WordsStyle name="USER DEFINED" styleID="17" fgColor="9F9D6D" bgColor="8AFFC5" fontName="" fontStyle="1" fontSize="" keywordClass="type7"></WordsStyle>
+            <WordsStyle name="TABLE DEFINITIONS" styleID="18" fgColor="9932CC" bgColor="201F1E" fontName="" fontStyle="5" fontSize=""></WordsStyle>
+            <WordsStyle name="TABLE SQL" styleID="19" fgColor="8A2BE2" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DLL FUNCTIONS" styleID="20" fgColor="000080" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DOMAIN DEFINITIONS" styleID="21" fgColor="B8860B" bgColor="201F1E" fontName="" fontStyle="5" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="22" fgColor="B22222" bgColor="201F1E" fontName="" fontStyle="5" fontSize=""></WordsStyle>
+            <WordsStyle name="OBJECT DEFINITIONS" styleID="23" fgColor="8080FF" bgColor="201F1E" fontName="" fontStyle="5" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROC DEFINITIONS" styleID="24" fgColor="556B2F" bgColor="201F1E" fontName="" fontStyle="5" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="bash" desc="bash" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="1" fgColor="EDD6ED" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="5" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SCALAR" styleID="9" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="PARAM" styleID="10" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HERE Q" styleID="13" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="batch" desc="Batch" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="LABEL" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMAND" styleID="5" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="blitzbasic" desc="BlitzBasic" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD1" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="10" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD3" styleID="11" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="KEYWORD4" styleID="12" fgColor="FDCEAE" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="LABEL" styleID="15" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="16" fgColor="EDD6ED" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HEXNUMBER" styleID="17" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="BINNUMBER" styleID="18" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="c" desc="C" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="cpp" desc="C++" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="cs" desc="C#" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="caml" desc="Caml" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="TYPE" styleID="5" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="LINENUM" styleID="6" fgColor="C2BE9E" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="8" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="11" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="12" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="cmake" desc="CMakeFile" ext="cmake">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING D" styleID="2" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING L" styleID="3" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING R" styleID="4" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMAND" styleID="5" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IFDEF" styleID="11" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="14" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="cobol" desc="COBOL" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DECLARATION" styleID="5" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="16" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="8" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="csound" desc="Csound" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="3" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTR" styleID="4" fgColor="C3BE98" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPCODE" styleID="6" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="HEADER STATEMENT" styleID="7" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS" styleID="8" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="9" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PARAMETER" styleID="10" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="A-RATE VARIABLE" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="K-RATE VARIABLE" styleID="12" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="I-RATE VARIABLE" styleID="13" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="GLOBAL VARIABLE" styleID="14" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="15" fgColor="000000" bgColor="E0C0E0" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="coffeescript" desc="CoffeeScript" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREDEFINED CONSTANT" styleID="19" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="22" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBOSE REGEX" styleID="23" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBOSE REGEX COMMENT" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="css" desc="CSS" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG" styleID="1" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS" styleID="2" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="UNKNOWN PSEUDOCLASS" styleID="4" fgColor="CEDF99" bgColor="FF0000" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="C2BE9E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="UNKNOWN IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VALUE" styleID="8" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="9" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="ID" styleID="10" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="BFCAA9" bgColor="274E27" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE STRING" styleID="13" fgColor="808080" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SINGLE STRING" styleID="14" fgColor="808080" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <!--WordsStyle name="IDENTIFIER2" styleID="15" fgColor="0040E0" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" /-->
+            <WordsStyle name="ATTRIBUTE" styleID="16" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <!--WordsStyle name="IDENTIFIER3" styleID="17" fgColor="00A0E0" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" /-->
+            <WordsStyle name="PSEUDOELEMENT" styleID="18" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <!--WordsStyle name="EXTENDED_IDENTIFIER" styleID="19" fgColor="7F7F00" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" /-->
+            <!-- LEGACY_PSEUDOELEMENT == EXTENDED_PSEUDOCLASS -->
+            <WordsStyle name="LEGACY PSEUDOELEMENT" styleID="20" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type5"></WordsStyle>
+            <!--WordsStyle name="EXTENDED_PSEUDOELEMENT" styleID="21" fgColor="7F7F00" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" /-->
+            <WordsStyle name="MEDIA" styleID="22" fgColor="E3C00B" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="23" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="d" desc="D" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="14" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="6" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORD1" styleID="7" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="8" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="KEYWORD3" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="KEYWORD4" styleID="20" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="KEYWORD5" styleID="21" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="KEYWORD6" styleID="22" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type5"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="10" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT NESTED" styleID="4" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING B" styleID="18" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING R" styleID="19" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="diff" desc="DIFF" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMAND" styleID="2" fgColor="DBDBBC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HEADER" styleID="3" fgColor="DEDEBE" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="POSITION" styleID="4" fgColor="FDCEAE" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DELETED" styleID="5" fgColor="CFBFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ADDED" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="erlang" desc="Erlang" ext="">
+            <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION COMMENT" styleID="14" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="MODULE COMMENT" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOCUMENTATION HELPER IN COMMENT" styleID="16" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="DOCUMENTATION MACRO IN COMMENT" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="2" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="5" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRO" styleID="10" fgColor="C2BE9E" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRO QUOTED" styleID="19" fgColor="C2BE9E" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="RECORD" styleID="11" fgColor="CFBFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="RECORD QUOTED" styleID="20" fgColor="CFBFAF" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="ATOM" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ATOM QUOTED" styleID="18" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NODE NAME" styleID="13" fgColor="FDCEAE" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NODE NAME QUOTED" styleID="21" fgColor="FDCEAE" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="RESERVED WORDS" styleID="4" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="BUILT-IN FUNCTIONS" styleID="22" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="FUNCTION NAME" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MODULE NAME" styleID="23" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MODULE ATTRIBUTES" styleID="24" fgColor="DBDBBC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="12" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="OPERATORS" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="UNKNOWN: ERROR" styleID="31" fgColor="EDD6ED" bgColor="2F2F2F" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="errorlist" desc="ErrorList" ext="">
+            <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PYTHON Error" styleID="1" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="GCC Error" styleID="2" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MS Error" styleID="3" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CMD Error" styleID="4" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BORLAND Error" styleID="5" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PERL Error" styleID="6" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NET Error" styleID="7" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LUA Error" styleID="8" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CTAG Error" styleID="9" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIFF Changed" styleID="10" fgColor="FF0080" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIFF Addition" styleID="11" fgColor="13A10E" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIFF Deletion" styleID="12" fgColor="CC0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIFF Message" styleID="13" fgColor="3A96DD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PHP Error" styleID="14" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ELF Error" styleID="15" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IFC Error" styleID="16" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IFORT Error" styleID="17" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ABSF Error" styleID="18" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TIDY Error" styleID="19" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="JAVA Stack Error" styleID="20" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VALUE Error" styleID="21" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="GCC Included-From Error" styleID="22" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="Escape Sequence" styleID="23" fgColor="C0C0C0" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="Unknown Escape Sequence" styleID="24" fgColor="FFFF78" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="GCC Excerpt Error" styleID="25" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BASH Error" styleID="26" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BLACK" styleID="40" fgColor="000000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR RED" styleID="41" fgColor="CD0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR GREEN" styleID="42" fgColor="00CD00" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BROWN" styleID="43" fgColor="AA5500" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BLUE" styleID="44" fgColor="0000FF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR MAGENTA" styleID="45" fgColor="CD00CD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR CYAN" styleID="46" fgColor="008888" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR GRAY" styleID="47" fgColor="E5E5E5" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR DARK GRAY" styleID="48" fgColor="7F7F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BRIGHT RED" styleID="49" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BRIGHT GREEN" styleID="50" fgColor="00FC00" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR YELLOW" styleID="51" fgColor="CCCC00" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BRIGHT BLUE" styleID="52" fgColor="3B78FF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BRIGHT MAGENTA" styleID="53" fgColor="FF00FF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR BRIGHT CYAN" styleID="54" fgColor="00CDCD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANSI COLOR WHITE" styleID="55" fgColor="FFFFFF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="escript" desc="ESCRIPT" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="LINE COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="DOC COMMENT" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATORS" styleID="7" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIERS" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BRACES" styleID="9" fgColor="CFBFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORDS2" styleID="10" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORDS3" styleID="11" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+        </LexerType>
+        <LexerType name="forth" desc="Forth" ext="">
+            <WordsStyle name="WHITESPACE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="ML COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CONTROL" styleID="4" fgColor="CFBFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="DEFWORDS" styleID="6" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="PREWORD1" styleID="7" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="PREWORD2" styleID="8" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="9" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="10" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="LOCALE" styleID="11" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="fortran" desc="Fortran" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="3" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING2" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="LABEL" styleID="13" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="3" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING2" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="LABEL" styleID="13" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="freebasic" desc="FreeBasic" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD1" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="10" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD3" styleID="11" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="KEYWORD4" styleID="12" fgColor="FDCEAE" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="LABEL" styleID="15" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="16" fgColor="EDD6ED" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HEXNUMBER" styleID="17" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="BINNUMBER" styleID="18" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="go" desc="Go" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="CEDFCE" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="gui4cli" desc="GUI4CLI" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="GLOBAL" styleID="3" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="EVENT" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="ATTRIBUTE" styleID="5" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="CONTROL" styleID="6" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="COMMAND" styleID="7" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="STRING" styleID="8" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="haskell" desc="Haskell" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS" styleID="6" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="MODULE" styleID="7" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA" styleID="9" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IMPORT" styleID="10" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="14" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK2" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK3" styleID="16" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="hollywood" desc="Hollywood" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="4" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="CORE API" styleID="5" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="PLUGIN API" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="PLUGIN METHOD" styleID="7" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="STRING" styleID="8" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING BLOCK" styleID="9" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="10" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="DCDCDC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="DCDCDC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CONSTANT" styleID="13" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEXNUMBER" styleID="14" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="html" desc="HTML" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="9" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SINGLE STRING" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG" styleID="1" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TAG END" styleID="11" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG UNKNOWN" styleID="2" fgColor="EDD6ED" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ATTRIBUTE UNKNOWN" styleID="4" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="SGML DEFAULT" styleID="21" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CDATA" styleID="17" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VALUE" styleID="19" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ENTITY" styleID="10" fgColor="CFBFAF" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="ihex" desc="Intel HEX" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECSTART" styleID="1" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECTYPE" styleID="2" fgColor="F0DFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTECOUNT" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTECOUNT_WRONG" styleID="5" fgColor="333333" bgColor="F18C96" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NOADDRESS" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATAADDRESS" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <!-- RECCOUNT 8 N/A -->
+            <WordsStyle name="STARTADDRESS" styleID="9" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="EXTENDEDADDRESS" styleID="11" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_ODD" styleID="12" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_EVEN" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_UNKNOWN" styleID="14" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_EMPTY" styleID="15" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHECKSUM" styleID="16" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CHECKSUM_WRONG" styleID="17" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="GARBAGE" styleID="18" fgColor="333333" bgColor="F18C96" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="ini" desc="ini file" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="SECTION" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEY" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="inno" desc="InnoSetup" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="SECTION" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="java" desc="Java" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="45" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="WORD" styleID="46" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="DOUBLE STRING" styleID="48" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SINGLE STRING" styleID="49" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="52" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="42" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="43" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="44" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="javascript.js" desc="JavaScript" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="WINDOW INSTRUCTION" styleID="19" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="json" desc="JSON" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="1" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="2" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING EOL" styleID="3" fgColor="808080" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PROPERTY NAME" styleID="4" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ESCAPE SEQUENCE" styleID="5" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="LINE COMMENT" styleID="6" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BLOCK COMMENT" styleID="7" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="URI" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMPACT IRI" styleID="10" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="11" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="LD KEYWORD" styleID="12" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="kix" desc="KiXtart" ext="">
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="2" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING2" styleID="3" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR" styleID="5" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRO" styleID="6" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="lisp" desc="LISP" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="FUNCTION WORD2" styleID="4" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="EDD6ED" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="12" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="latex" desc="LaTeX" ext="">
+            <WordsStyle name="WHITE SPACE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMAND" styleID="1" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG OPENING" styleID="2" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="MATH INLINE" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="4" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG CLOSING" styleID="5" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="MATH BLOCK" styleID="6" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="7" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM SEGMENT" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SHORT COMMAND" styleID="9" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SPECIAL CHAR" styleID="10" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMAND OPTIONAL ARGUMENT" styleID="11" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SYNTAX ERROR" styleID="12" fgColor="ECA9A9" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="lua" desc="Lua" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNC1" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="FUNC2" styleID="14" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="FUNC3" styleID="15" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type5"></WordsStyle>
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type6"></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LABEL" styleID="20" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+        </LexerType>
+        <LexerType name="makefile" desc="Makefile" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="TARGET" styleID="5" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDEOL" styleID="9" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="matlab" desc="Matlab" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMAND" styleID="2" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="5" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="mmixal" desc="MMIXAL" ext="">
+            <WordsStyle name="DIVSION OF LEADING WHITESPACE IN LINE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="LABEL" styleID="2" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="OPCODE" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIVISION BETWEEN LABEL AND OPCODE" styleID="4" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VALID OPCODE" styleID="5" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="UNKNOWN OPCODE" styleID="6" fgColor="333333" bgColor="F18C96" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIVISION BETWEEN OPCODE AND OPERANDS" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DIVISION OF OPERANDS" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="9" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REFERENCE (TO A LABEL)" styleID="10" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="CHAR" styleID="11" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="12" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGISTER" styleID="13" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="HEXADECIMAL NUMBER" styleID="14" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="15" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SYMBOL" styleID="16" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="COMMENT OTHERWISE" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="mssql" desc="MS T-SQL" ext="">
+            <WordsStyle name="STATEMENT" styleID="9" fgColor="F08080" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="DATA TYPE" styleID="10" fgColor="A082BD" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="SYSTEM TABLE" styleID="11" fgColor="378BF0" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="GLOBAL" styleID="12" fgColor="37CFC0" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="13" fgColor="ADDB67" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="SYSTEM STORED PROC" styleID="14" fgColor="E385FF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="A0A0A0" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="A0A0A0" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FFC600" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="F1F1B9" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="B08000" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="C0FFFF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="66D9EF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COL NAME" styleID="8" fgColor="82AAFF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COL NAME IN []&apos;s" styleID="16" fgColor="82AAFF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="nfo" desc="Dos Style" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="DCDCCC" bgColor="201F1E" fontSize="" fontStyle="0"></WordsStyle>
+        </LexerType>
+        <LexerType name="nsis" desc="NSIS" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="LABEL" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="4" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="SECTION" styleID="9" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRO" styleID="12" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="14" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="4" fontSize=""></WordsStyle>
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="nim" desc="Nim" ext="">
+            <WordsStyle name="WHITE SPACE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="3" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SINGLE QUOTED STRING" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TRIPLE QUOTES" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="TRIPLE DOUBLE QUOTES" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS NAME DEFINITION" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION OR METHOD NAME DEFINITION" styleID="9" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATORS" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIERS" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT-BLOCKS" styleID="12" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="END OF LINE WHERE STRING IS NOT CLOSED" styleID="13" fgColor="CC9393" bgColor="2F2F2F" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HIGHLIGHTED IDENTIFIERS" styleID="14" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DECORATORS" styleID="15" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="nncrontab" desc="extended crontab" ext="">
+            <WordsStyle name="WHITESPACE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="TASK START/END" styleID="2" fgColor="CEDF99" bgColor="303030" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SECTION KEYWORDS" styleID="3" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="4" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="MODIFICATORS" styleID="5" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="2" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="ASTERISK" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="7" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE QUOTED STRING" styleID="8" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ENVIRONMENT VARIABLE" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="10" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="oscript" desc="OScript" ext="">
+            <WordsStyle name="DEFAULT TEXT STYLE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SINGLE-LINE COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="MULTI-LINE COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="#IFDEF DOC AND #ENDIF" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR DIRECTIVE" styleID="4" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING SINGLE QUOTES" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING DOUBLE QUOTES" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CONSTANT LITERAL" styleID="8" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SERVER-GLOBAL VARIABLE (PREFIXED BY $)" styleID="10" fgColor="FDCEAE" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LANGUAGE NATIVE KEYWORD OR RESERVED WORD" styleID="11" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="OPERATOR; EITHER SYMBOLIC OR LITERAL" styleID="12" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="LABEL TO JUMP TO WITH THE GOTO STATEMENT" styleID="13" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="14" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="15" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="STATIC BUILT-IN OBJECT" styleID="16" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="OBJECT PROPERTY" styleID="17" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OBJECT METHOD" styleID="18" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="objc" desc="Objective-C" ext="">
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="pascal" desc="Pascal" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="4" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR2" styleID="6" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="7" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEX NUMBER" styleID="8" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="10" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ASM" styleID="14" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="perl" desc="Perl" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SCALAR" styleID="12" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ARRAY" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HASH" styleID="14" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PROTOTYPE" styleID="40" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING Q" styleID="26" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING QQ" styleID="27" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING QX" styleID="28" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING QR" styleID="29" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING QW" styleID="30" fgColor="FFC3C3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TRANSLATION" styleID="44" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="FFC3C3" bgColor="303030" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="DCA3A3" bgColor="303030" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEREDOC DOUBLEQUOTE" styleID="24" fgColor="CC9393" bgColor="303030" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEREDOC BACKTICK" styleID="25" fgColor="DCDCCC" bgColor="303030" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN STRING" styleID="43" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN REGEX" styleID="54" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN REGEX SUBSTITUTION" styleID="55" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN BACKTICKS" styleID="57" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN HEREDOC DOUBLEQUOTE" styleID="61" fgColor="CC9393" bgColor="303030" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN HEREDOC BACKTICK" styleID="62" fgColor="DCDCCC" bgColor="303030" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN STRING QQ" styleID="64" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN STRING QX" styleID="65" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="9FBF9F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="FORMAT BODY" styleID="42" fgColor="9FBF9F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="POD" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="POD VERBATIM" styleID="31" fgColor="9FBF9F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="1" fgColor="EBD6EB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="php" desc="php" ext="">
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="119" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMPLEX VARIABLE" styleID="104" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SIMPLE STRING" styleID="120" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="WORD" styleID="121" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="122" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="124" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="125" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+        </LexerType>
+        <LexerType name="postscript" desc="Postscript" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="Name" styleID="5" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="LITERAL" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="TEXT" styleID="12" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="ECA9A9" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="powershell" desc="PowerShell" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="2" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="3" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="5" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="CMDLET" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="ALIAS" styleID="10" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="11" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS" styleID="12" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="COMMENT STREAM" styleID="13" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HERE STRING" styleID="14" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HERE CHARACTER" styleID="15" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type4"></WordsStyle>
+        </LexerType>
+        <LexerType name="props" desc="Properties file" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SECTION" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="KEY" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="purebasic" desc="PureBasic" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD1" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="10" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD3" styleID="11" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="KEYWORD4" styleID="12" fgColor="FDCEAE" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="CONSTANT" styleID="13" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LABEL" styleID="15" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="16" fgColor="EDD6ED" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="HEXNUMBER" styleID="17" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="BINNUMBER" styleID="18" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="python" desc="Python" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="3" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TRIPLE DOUBLE" styleID="7" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="12" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DECORATOR" styleID="15" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="ATTRIBUTE" styleID="20" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="F STRING" styleID="16" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="F CHARACTER" styleID="17" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="r" desc="R" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="2" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="BASE WORD" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="4" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING2" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="INFIX" styleID="10" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INFIXEOL" styleID="11" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BACKTICKS" styleID="12" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RAWSTRING" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RAWSTRING2" styleID="14" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ESCAPESEQUENCE" styleID="15" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="raku" desc="Raku" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="1" fgColor="EBD6EB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT EMBED" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="POD" styleID="4" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEREDOC Q" styleID="6" fgColor="DCA3A3" bgColor="303030" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEREDOC QQ" styleID="7" fgColor="CC9393" bgColor="303030" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="8" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING Q" styleID="9" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING QQ" styleID="10" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING Q_LANG" styleID="11" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING VAR" styleID="12" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX MATCH" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX VAR" styleID="14" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="ADVERB" styleID="15" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type5"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="16" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="17" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="18" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="19" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="21" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <!-- "TYPEDEF" styling applies to type1..type4 lists from langs.xml, but only associated with type1 in stylers/themes -->
+            <WordsStyle name="TYPEDEF" styleID="22" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="MU" styleID="23" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="POSITIONAL" styleID="24" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ASSOCIATIVE" styleID="25" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CALLABLE" styleID="26" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="GRAMMAR" styleID="27" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS" styleID="28" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="rc" desc="RC" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="rebol" desc="REBOL" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANY OTHER TEXT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="LINE COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="BLOCK COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="PREFACE" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATORS" styleID="4" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTERS" styleID="5" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING WITH QUOTES" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING WITH BRACES" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="8" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PAIR ( 800X600 )" styleID="9" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="TUPLE ( 127.0.0.1 )" styleID="10" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BINARY ( 16#{1A803F59} )" styleID="11" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MONEY" styleID="12" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ISSUE { #123-CD-456 }" styleID="13" fgColor="EBD6EB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG { &lt;TITLE HEIGHT=100&gt; }" styleID="14" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="FILE { %/C/WINNT/SOME.DLL }" styleID="15" fgColor="DCDCCC" bgColor="333333" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="EMAIL { JOE@MAIL.DOM }" styleID="16" fgColor="DCDCCC" bgColor="333333" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="URL { FTP://THERE.DOM }" styleID="17" fgColor="DCDCCC" bgColor="333333" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATE { 17-FEB-2004 1/3/99 }" styleID="18" fgColor="DCDCCC" bgColor="333333" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TIME { 12:30 11:22:59 01:59:59.123 }" styleID="19" fgColor="DCDCCC" bgColor="333333" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIERS" styleID="20" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD (ALL)" styleID="21" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORD (TEST FUNCTIONS)" styleID="22" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD (DATATYPES)" styleID="23" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="KEYWORD 4" styleID="24" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="KEYWORD 5" styleID="25" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="KEYWORD 6" styleID="26" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="KEYWORD 7" styleID="27" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type5"></WordsStyle>
+        </LexerType>
+        <LexerType name="registry" desc="registry" ext="">
+            <WordsStyle name="DEFAULT STYLE" styleID="32" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="VALUE NAME" styleID="2" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="3" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HEX DIGIT" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VALUE TYPE" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ADDED KEY" styleID="6" fgColor="709080" bgColor="313C36" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="REMOVED KEY" styleID="7" fgColor="CFBFAF" bgColor="41363C" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ESCAPED CHARACTERS IN STRINGS" styleID="8" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="GUID IN KEY PATH" styleID="9" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="GUID IN STRING" styleID="10" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="PARAMETER" styleID="11" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATORS" styleID="12" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="ruby" desc="Ruby" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="1" fgColor="EBD6EB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="POD" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="DFE4CF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="12" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING Q" styleID="24" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="rust" desc="Rust" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="WHITESPACE" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BLOCK COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LINE COMMENT" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BLOCK DOC COMMENT" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LINE DOC COMMENT" styleID="4" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORDS 1" styleID="6" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORDS 2" styleID="7" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORDS 3" styleID="8" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="KEYWORDS 4" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="KEYWORDS 5" styleID="10" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="KEYWORDS 6" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="KEYWORDS 7" styleID="12" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type5"></WordsStyle>
+            <WordsStyle name="REGULAR STRING" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RAW STRING" styleID="14" fgColor="DFAF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="16" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="17" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LIFETIME" styleID="18" fgColor="BFEBBF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRO" styleID="19" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LEXICAL ERROR" styleID="20" fgColor="EBD6EB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTE STRING" styleID="21" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="RAW BYTE STRING" styleID="22" fgColor="DFAF8F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTE CHARACTER" styleID="23" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="C STRING" styleID="24" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RAW C STRING" styleID="25" fgColor="DFAF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="sas" desc="SAS" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRO" styleID="11" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MACRO KEYWORD" styleID="12" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="MACRO FUNCTION" styleID="14" fgColor="9FBF9F" bgColor="201F1E" fontName="" fontStyle="3" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="STATEMENT" styleID="15" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type2"></WordsStyle>
+        </LexerType>
+        <LexerType name="scheme" desc="Scheme" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="FUNCTION WORD2" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="12" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="smalltalk" desc="Smalltalk" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="1" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="BINARY" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BOOL" styleID="6" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SELF" styleID="7" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SUPER" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NIL" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RETURN" styleID="11" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KWS END" styleID="13" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="spice" desc="spice" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIERS" styleID="1" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="3" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD3" styleID="4" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATORS (DELIMITERS)" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VALUE" styleID="7" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="8" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="sql" desc="SQL" ext="">
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="USER1" styleID="16" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING2" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="808080" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="srec" desc="S-Record" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECSTART" styleID="1" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECTYPE" styleID="2" fgColor="F0DFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTECOUNT" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTECOUNT_WRONG" styleID="5" fgColor="333333" bgColor="F18C96" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NOADDRESS" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATAADDRESS" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECCOUNT" styleID="8" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STARTADDRESS" styleID="9" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <!-- EXTENDEDADDRESS 11 N/A -->
+            <WordsStyle name="DATA_ODD" styleID="12" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_EVEN" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_UNKNOWN" styleID="14" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_EMPTY" styleID="15" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHECKSUM" styleID="16" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CHECKSUM_WRONG" styleID="17" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="GARBAGE" styleID="18" fgColor="333333" bgColor="F18C96" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="swift" desc="SWIFT" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT" styleID="23" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="tcl" desc="TCL" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="EXPAND" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="tehex" desc="Tektronix extended HEX" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECSTART" styleID="1" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECTYPE" styleID="2" fgColor="F0DFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="RECTYPE_UNKNOWN" styleID="3" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTECOUNT" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="BYTECOUNT_WRONG" styleID="5" fgColor="333333" bgColor="F18C96" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <!-- NOADDRESS 6 N/A -->
+            <WordsStyle name="DATAADDRESS" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <!-- RECCOUNT 8 N/A -->
+            <WordsStyle name="STARTADDRESS" styleID="9" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ADDRESSFIELD_UNKNOWN" styleID="10" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <!-- EXTENDEDADDRESS 11 N/A -->
+            <WordsStyle name="DATA_ODD" styleID="12" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DATA_EVEN" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <!-- DATA_UNKNOWN 14 N/A -->
+            <!-- DATA_EMPTY 15 N/A -->
+            <WordsStyle name="CHECKSUM" styleID="16" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CHECKSUM_WRONG" styleID="17" fgColor="80D4AA" bgColor="2F2F2F" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="GARBAGE" styleID="18" fgColor="333333" bgColor="F18C96" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="tex" desc="TeX" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="GROUP" styleID="2" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMAND" styleID="4" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="TEXT" styleID="5" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="toml" desc="TOML" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="69B45C" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="C0C0C0" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="3" fgColor="B76FFF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TABLE" styleID="5" fgColor="FED750" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="KEY" styleID="6" fgColor="8CC6FF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="7" fgColor="FF0000" bgColor="201F1E" fontName="" fontStyle="4" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="C0C0C0" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING SQ" styleID="9" fgColor="CE9B9B" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING DQ" styleID="10" fgColor="CE9B9B" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="TRIPLE STRING SQ" styleID="11" fgColor="CE9B9B" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="TRIPLE STRING DQ" styleID="12" fgColor="CE9B9B" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ESCAPE CHAR" styleID="13" fgColor="00FF00" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="txt2tags" desc="txt2tags" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="DCDCDC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRONG" styleID="2" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRONG 2 (NOT USED)" styleID="3" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="EM1 (ITALIC)" styleID="4" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="EM2 (UNDERLINE)" styleID="5" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="H1" styleID="6" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="H2" styleID="7" fgColor="C2D390" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="H3" styleID="8" fgColor="BCCD8A" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="H4" styleID="9" fgColor="AEBF79" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="H5" styleID="10" fgColor="A2B370" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="H6" styleID="11" fgColor="9CAD6A" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="PRECHAR (NOT USED)" styleID="12" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="LIST" styleID="13" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="LIST" styleID="14" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="BLOCKQUOTE" styleID="15" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRIKEOUT" styleID="16" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="HRULE" styleID="17" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="LINK" styleID="18" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="CODE" styleID="19" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CODE2" styleID="20" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CODEBLOCK" styleID="21" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="22" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPTION" styleID="23" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROC" styleID="24" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="POSTPROC" styleID="25" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="typescript" desc="TypeScript" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="WINDOW INSTRUCTION" styleID="19" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="DCA3A3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="vb" desc="VB / VBS" ext="">
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="WORD" styleID="3" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="DATE" styleID="8" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="verilog" desc="Verilog" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="USER" styleID="19" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="vhdl" desc="VHDL" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="15" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="4" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type3"></WordsStyle>
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type4"></WordsStyle>
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="FFEBDD" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="type5"></WordsStyle>
+        </LexerType>
+        <LexerType name="visualprolog" desc="Visual Prolog" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="MAJOR" styleID="1" fgColor="EFEF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="MINOR" styleID="2" fgColor="DFAF8F" bgColor="201F1E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"></WordsStyle>
+            <WordsStyle name="DIRECTIVE" styleID="3" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type1"></WordsStyle>
+            <WordsStyle name="COMMENT BLOCK" styleID="4" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT LINE" styleID="5" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT KEY" styleID="6" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="type2"></WordsStyle>
+            <WordsStyle name="COMMENT KEY ERROR" styleID="7" fgColor="7F9F7F" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ANONYMOUS" styleID="10" fgColor="93E0E3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="11" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="12" fgColor="9F9D6D" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER" styleID="13" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER TOO MANY" styleID="14" fgColor="CC9393" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="CHARACTER ESCAPE ERROR" styleID="15" fgColor="CC9393" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING" styleID="16" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING ESCAPE" styleID="17" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING ESCAPE ERROR" styleID="18" fgColor="CC9393" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING EOL OPEN" styleID="19" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING VERBATIM" styleID="20" fgColor="EFEFEF" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING VERBATIM SPECIAL" styleID="21" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="STRING VERBATIM EOL" styleID="22" fgColor="CC9393" bgColor="2F2F2F" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="xml" desc="XML" ext="">
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="XMLEND" styleID="13" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="9" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="5" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOUBLE STRING" styleID="6" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="SINGLE STRING" styleID="7" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG" styleID="1" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG END" styleID="11" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TAG UNKNOWN" styleID="2" fgColor="EDD6ED" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="ATTRIBUTE UNKNOWN" styleID="4" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="SGML DEFAULT" styleID="21" fgColor="DFDFDF" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="CDATA" styleID="17" fgColor="C89191" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ENTITY" styleID="10" fgColor="CFBFAF" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="BEC89E" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="substyle8"></WordsStyle>
+        </LexerType>
+        <LexerType name="yaml" desc="YAML" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="FFCFAF" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="201F1E" fontName="" fontStyle="3" fontSize=""></WordsStyle>
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="DFC47D" bgColor="201F1E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1"></WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="REFERENCE" styleID="5" fgColor="CEDF99" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="DOCUMENT" styleID="6" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="TEXT" styleID="7" fgColor="CC9393" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WordsStyle>
+            <WordsStyle name="ERROR" styleID="8" fgColor="EBD6EB" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+        </LexerType>
+        <LexerType name="searchResult" desc="Search result" ext="">
+            <WordsStyle name="Search Header" styleID="1" fgColor="101010" bgColor="8FAF9F" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="File Header" styleID="2" fgColor="E3CEAB" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="Line Number" styleID="3" fgColor="8CD0D3" bgColor="201F1E" fontName="" fontStyle="2" fontSize=""></WordsStyle>
+            <WordsStyle name="Hit Word" styleID="4" fgColor="CCE08C" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WordsStyle>
+            <WordsStyle name="Current line background colour" styleID="6" bgColor="585858"></WordsStyle>
+        </LexerType>
+    </LexerStyles>
+    <GlobalStyles>
+        <!-- Attention : Don't modify the name of styleID="0" -->
+        <WidgetStyle name="Default Style" styleID="32" fgColor="DCDCCC" bgColor="201F1E" fontName="Consolas" fontStyle="0" fontSize="10"></WidgetStyle>
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="4F5F5F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WidgetStyle>
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="F0F9F9" bgColor="201F1E" fontName="" fontStyle="1" fontSize=""></WidgetStyle>
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="F09F9F" bgColor="201F1E" fontName="" fontStyle="0" fontSize=""></WidgetStyle>
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="101010"></WidgetStyle>
+        <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="585858" fgColor="000000"></WidgetStyle>
+        <WidgetStyle name="Multi-selected text color" styleID="0" bgColor="C0C0C0"></WidgetStyle>
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="8FAF9F"></WidgetStyle>
+        <WidgetStyle name="Multi-edit carets color" styleID="0" fgColor="808040"></WidgetStyle>
+        <WidgetStyle name="Edge colour" styleID="0" fgColor="4F5F5F"></WidgetStyle>
+        <WidgetStyle name="Line number margin" styleID="33" fgColor="8A8A8A" bgColor="0A0A0A" fontName="" fontStyle="0" fontSize=""></WidgetStyle>
+        <WidgetStyle name="Bookmark margin" styleID="0" bgColor="0A0A0A"></WidgetStyle>
+        <WidgetStyle name="Change History margin" styleID="0" bgColor="0A0A0A"></WidgetStyle>
+        <WidgetStyle name="Change History modified" styleID="0" fgColor="FF8000" bgColor="FF8000"></WidgetStyle>
+        <WidgetStyle name="Change History revert modified" styleID="0" fgColor="A0C000" bgColor="A0C000"></WidgetStyle>
+        <WidgetStyle name="Change History revert origin" styleID="0" fgColor="40A0BF" bgColor="40A0BF"></WidgetStyle>
+        <WidgetStyle name="Change History saved" styleID="0" fgColor="00A000" bgColor="00A000"></WidgetStyle>
+        <WidgetStyle name="Fold" styleID="0" fgColor="707070" bgColor="101010"></WidgetStyle>
+        <WidgetStyle name="Fold active" styleID="0" fgColor="7F9F7F"></WidgetStyle>
+        <WidgetStyle name="Fold margin" styleID="0" fgColor="181818" bgColor="101010"></WidgetStyle>
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="5F5F5F"></WidgetStyle>
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="358A35"></WidgetStyle>
+        <WidgetStyle name="Find Mark Style" styleID="31" bgColor="FF0080"></WidgetStyle>
+        <WidgetStyle name="Find status: Not found" styleID="0" fgColor="FF0000"></WidgetStyle>
+        <WidgetStyle name="Find status: Message" styleID="0" fgColor="0000FF"></WidgetStyle>
+        <WidgetStyle name="Find status: Search end reached" styleID="0" fgColor="008000"></WidgetStyle>
+        <WidgetStyle name="Mark Style 1" styleID="25" bgColor="88B090"></WidgetStyle>
+        <WidgetStyle name="Mark Style 2" styleID="24" bgColor="F8F893"></WidgetStyle>
+        <WidgetStyle name="Mark Style 3" styleID="23" bgColor="F18C96"></WidgetStyle>
+        <WidgetStyle name="Mark Style 4" styleID="22" bgColor="408040"></WidgetStyle>
+        <WidgetStyle name="Mark Style 5" styleID="21" bgColor="968CF1"></WidgetStyle>
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="C3BF9F"></WidgetStyle>
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="C6C600"></WidgetStyle>
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="78926F"></WidgetStyle>
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="80D4B2"></WidgetStyle>
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="3FBA89"></WidgetStyle>
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="101010"></WidgetStyle>
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0"></WidgetStyle>
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB"></WidgetStyle>
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB"></WidgetStyle>
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3"></WidgetStyle>
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB"></WidgetStyle>
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE"></WidgetStyle>
+        <WidgetStyle name="Tab color dark mode 1" styleID="0" bgColor="807848"></WidgetStyle>
+        <WidgetStyle name="Tab color dark mode 2" styleID="0" bgColor="568048"></WidgetStyle>
+        <WidgetStyle name="Tab color dark mode 3" styleID="0" bgColor="507094"></WidgetStyle>
+        <WidgetStyle name="Tab color dark mode 4" styleID="0" bgColor="804849"></WidgetStyle>
+        <WidgetStyle name="Tab color dark mode 5" styleID="0" bgColor="754880"></WidgetStyle>
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="A3DCA3"></WidgetStyle>
+        <WidgetStyle name="Document map" styleID="0" fgColor="000000" bgColor="FFFFFF"></WidgetStyle>
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080"></WidgetStyle>
+        <WidgetStyle name="Non-printing characters custom color" styleID="0" fgColor="5F5F5F"></WidgetStyle>
+        <WidgetStyle name="Global override" styleID="0" fgColor="DCDCCC" bgColor="201F1E" fontName="Consolas" fontStyle="0" fontSize="10"></WidgetStyle>
+    </GlobalStyles>
+</NotepadPlus>


### PR DESCRIPTION
Takes the OneNotepad++.Dark.xml theme which @caskexe uploaded in #39, with two changes:
- Change `--` to `-` inside comments (`--` has special meaning in XML comments: even though most xml parsers only care about the `<!--` at the start and `-->` at the end, technically intervening `--` _do_ toggle whether inside or outside the comment)
- Move the comments inside the `<NotepadPlus>` element (because comments before XML declaration are not strictly allowed in XML)
