### PR TITLE
Require XML encoding for themes

### DIFF
--- a/.validators/validator_xml.py
+++ b/.validators/validator_xml.py
@@ -3,6 +3,7 @@
 import os
 import io
 import sys
+import re
 
 import requests
 from lxml import etree
@@ -50,6 +51,21 @@ def parse_xml_file(filename_xml, filename_xsd = None):
     except:
         #print('Unknown error.')
         post_error(f'{filename_xml}: Unknown error. Maybe check that no xml version is in the first line.')
+
+    # UDL #392: require prolog set the encoding
+    try:
+        encoding = get_prolog_encoding(filename_xml)
+        if encoding is None or encoding.upper() != "UTF-8":
+            post_error({
+                'filename': filename_xml,
+                'found_encoding': encoding,
+                'message': 'XML prolog encoding must be UTF-8'
+            })
+            return
+
+    except Exception as e:
+        post_error(f'{filename_xml}: Failed to extract XML prolog and/or encoding: "{e}"')
+        return
 
 
     ##### check XML using XSD
@@ -107,6 +123,47 @@ def output_json_toc(tocname, xlst):
     #print(f'{tocname} =>\n' + json.dumps(sorted(xlst, key=str.casefold), indent=4))
     with open(tocname, "w", encoding="utf8") as toc_file:
         json.dump(sorted(xlst, key=str.casefold), toc_file, indent=4)
+
+
+def get_prolog_encoding(filename: str) -> str | None:
+    """
+    Analyzes the raw XML prolog to check for an explicit encoding attribute.
+
+    Returns:
+        None (type)  - If there is absolutely no xml prolog found.
+        None (type)  - If a prolog exists, but the encoding attribute is missing.
+        "" (str)     - If the encoding attribute is explicitly empty (encoding="").
+        str          - The literal value of the encoding attribute if specified.
+    """
+    # Look only at the first 2048 bytes; XML declarations must start at byte 0
+    with open(filename, 'rb') as f:
+        chunk = f.read(2048)
+
+    # Check if the file starts with the XML declaration opener
+    # Account for standard UTF-8/ASCII or common byte-order marks (BOM)
+    if b'<?xml' not in chunk:
+        return None
+
+    # Extract the full prolog string up to its closing tag
+    try:
+        prolog_bytes = chunk.split(b'?>')[0] + b'?>'
+        prolog_str = prolog_bytes.decode('utf-8', errors='ignore')
+    except Exception:
+        return None
+
+    # Strict regex check for the declaration block
+    if not re.match(r'^\s*<\?xml\s', prolog_str):
+        return None
+
+    # Search for the encoding attribute and capture its quote-bounded contents
+    match = re.search(r'\bencoding\s*=\s*(["\'])(.*?)\1', prolog_str)
+
+    if match:
+        return match.group(2)  # Returns actual value, or "" if empty
+
+    return None  # Prolog exists, but encoding attribute does not
+
+
 
 my_list = parse_xml_files_from_themes_dir()
 output_json_toc('themes/.toc.json', my_list)

--- a/.validators/validator_xml.py
+++ b/.validators/validator_xml.py
@@ -62,6 +62,9 @@ def parse_xml_file(filename_xml, filename_xsd = None):
                 'message': 'XML prolog encoding must be UTF-8'
             })
             return
+        else:
+            print(f'{filename_xml} prolog: UTF-8 ENCODING OK')
+
 
     except Exception as e:
         post_error(f'{filename_xml}: Failed to extract XML prolog and/or encoding: "{e}"')

--- a/README.md
+++ b/README.md
@@ -24,20 +24,29 @@ It is also possible to use the menu entry [Settings > Import > Import Style Them
 
 ## Submitting your Theme to the Collection
 
+### Requirements
+
+- **requirement**: XML prolog / declaration
+    - There _must_ be an XML prolog/declaration as the first line in the file
+    - The prolog/declaration _must_ include encoding attribute
+    - The file encoding (and prolog/declaration encoding attribute) must use UTF-8
+- **requirement**: Any comment block must come _after_ the XML prolog / declaration
+
 ### Theme Best Practices
 
-- Include a comment block near the top of the theme, listing things including
+- Include a comment block near the top of the theme (but _after_ the XML prolog / declaration), listing things including
    - Name of the Theme
    - Author (you)
    - Date of creation or last modification
    - Any other credits or acknowledgements or notes you'd like the user to see when downloading
+   - **requirement**: The comments must not contain a license or copyright notice that contradicts the [Automatic License](#automatic-license) found in the Collection's [LICENSE](./LICENSE) file
 - When possible, make use of "background inheritance" (set `colorStyle="1"` in the raw XML or right click on the **Background colour** input in the Style Configurator) so that styles for various language markups inherit the **Default Style**'s background colour -- this will mean that a user of your theme only has to change one entry to get the background to change on hundreds of style entries.  The [99er theme](https://github.com/notepad-plus-plus/nppThemes/blob/main/themes/99er.xml) includes the steps used to do that in a bulk search-and-replace to the raw XML.
 
 See the [default styler](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/stylers.model.xml) and the [themes included with Notepad++ distributions](https://github.com/notepad-plus-plus/notepad-plus-plus/tree/master/PowerEditor/installer/themes) for good examples of Themes.
 
 ### Submission Process
 
-You can submit your Theme file(s) into this repo if you would like to share it with the general public.  
+You can submit your Theme file(s) into this repo if you would like to share it with the general public.
 
 To do so, you may either:
 - Create a Pull Request: create your own fork of this repository; add the new theme XML file to the themes folder your fork; and finally, create the Pull Request (PR).
@@ -49,7 +58,7 @@ The Theme Collection team will validate your theme (using manual review and/or a
 
 Since many contributors are not GitHub experts, we have added in this section to make it easier for you to submit your file in a Pull Request (PR)
 
-0. Create a GitHub account 
+0. Create a GitHub account
    - Without an account, you cannot submit a PR
 2. Create a **fork** of the Themes Collection
    - Click the **Fork** label/icon from the [main Notepad++ Themes Collection page](https://github.com/notepad-plus-plus/nppThemes)
@@ -59,7 +68,7 @@ Since many contributors are not GitHub experts, we have added in this section to
    - Upload the Theme's XML file to the `themes/` folder _in your fork_
 4. Create a PR from your fork
     - from your fork's master branch, after you've made the changes above,
-    - click the down arrow on **Contribute** 
+    - click the down arrow on **Contribute**
     - select **Open Pull Request**
     - fill out your description for the PR, and submit the PR
 

--- a/themes/Dust Light.xml
+++ b/themes/Dust Light.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
 Notepad++ Custom Style
 

--- a/themes/Industrial Whir.xml
+++ b/themes/Industrial Whir.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
 Notepad++ Custom Style
 

--- a/themes/Tangara-FontFree.xml
+++ b/themes/Tangara-FontFree.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
 Notepad++ Custom Style
 


### PR DESCRIPTION
- Add requirement for prolog + UTF-8 encoding to README
- Add check for prolog + UTF-8 encoding in validator
- Fix existing themes to meet new requirement

fixes https://github.com/notepad-plus-plus/userDefinedLanguages/issues/392#issuecomment-4448307135
